### PR TITLE
Enable await in expressions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+lib/server/await.js

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,4 +11,5 @@ Kevin Kwok <kkwok@mit.edu>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>
 Thales Mello <thalesmello@gmail.com>
+Vadim Markovtsev <vadim@sourced.tech>
 Will Whitney <wfwhitney@gmail.com>

--- a/lib/server/await.js
+++ b/lib/server/await.js
@@ -1,0 +1,132 @@
+// Copied from node/lib/internal/repl/await.js since it cannot be imported directly.
+// Node's license is MIT, see https://github.com/nodejs/node/blob/master/LICENSE
+// Acorn's license is MIT, see https://github.com/acornjs/acorn/blob/master/LICENSE
+
+'use strict';
+
+const acorn = require('acorn/dist/acorn');
+const walk = require('acorn/dist/walk');
+
+const noop = () => {};
+const visitorsWithoutAncestors = {
+  ClassDeclaration(node, state, c) {
+    if (state.ancestors[state.ancestors.length - 2] === state.body) {
+      state.prepend(node, `${node.id.name}=`);
+    }
+    walk.base.ClassDeclaration(node, state, c);
+  },
+  FunctionDeclaration(node, state, c) {
+    state.prepend(node, `${node.id.name}=`);
+  },
+  FunctionExpression: noop,
+  ArrowFunctionExpression: noop,
+  MethodDefinition: noop,
+  AwaitExpression(node, state, c) {
+    state.containsAwait = true;
+    walk.base.AwaitExpression(node, state, c);
+  },
+  ReturnStatement(node, state, c) {
+    state.containsReturn = true;
+    walk.base.ReturnStatement(node, state, c);
+  },
+  VariableDeclaration(node, state, c) {
+    if (node.kind === 'var' ||
+        state.ancestors[state.ancestors.length - 2] === state.body) {
+      if (node.declarations.length === 1) {
+        state.replace(node.start, node.start + node.kind.length, 'void');
+      } else {
+        state.replace(node.start, node.start + node.kind.length, 'void (');
+      }
+
+      for (const decl of node.declarations) {
+        state.prepend(decl, '(');
+        state.append(decl, decl.init ? ')' : '=undefined)');
+      }
+
+      if (node.declarations.length !== 1) {
+        state.append(node.declarations[node.declarations.length - 1], ')');
+      }
+    }
+
+    walk.base.VariableDeclaration(node, state, c);
+  }
+};
+
+const visitors = {};
+for (const nodeType of Object.keys(walk.base)) {
+  const callback = visitorsWithoutAncestors[nodeType] || walk.base[nodeType];
+  visitors[nodeType] = (node, state, c) => {
+    const isNew = node !== state.ancestors[state.ancestors.length - 1];
+    if (isNew) {
+      state.ancestors.push(node);
+    }
+    callback(node, state, c);
+    if (isNew) {
+      state.ancestors.pop();
+    }
+  };
+}
+
+function processTopLevelAwait(src) {
+  const wrapped = `(async () => { ${src} })()`;
+  const wrappedArray = wrapped.split('');
+  let root;
+  try {
+    root = acorn.parse(wrapped, { ecmaVersion: 10 });
+  } catch (err) {
+    return null;
+  }
+  const body = root.body[0].expression.callee.body;
+  const state = {
+    body,
+    ancestors: [],
+    replace(from, to, str) {
+      for (var i = from; i < to; i++) {
+        wrappedArray[i] = '';
+      }
+      if (from === to) str += wrappedArray[from];
+      wrappedArray[from] = str;
+    },
+    prepend(node, str) {
+      wrappedArray[node.start] = str + wrappedArray[node.start];
+    },
+    append(node, str) {
+      wrappedArray[node.end - 1] += str;
+    },
+    containsAwait: false,
+    containsReturn: false
+  };
+
+  walk.recursive(body, state, visitors);
+
+  // Do not transform if
+  // 1. False alarm: there isn't actually an await expression.
+  // 2. There is a top-level return, which is not allowed.
+  if (!state.containsAwait || state.containsReturn) {
+    return null;
+  }
+
+  const last = body.body[body.body.length - 1];
+  if (last.type === 'ExpressionStatement') {
+    // For an expression statement of the form
+    // ( expr ) ;
+    // ^^^^^^^^^^   // last
+    //   ^^^^       // last.expression
+    //
+    // We do not want the left parenthesis before the `return` keyword;
+    // therefore we prepend the `return (` to `last`.
+    //
+    // On the other hand, we do not want the right parenthesis after the
+    // semicolon. Since there can only be more right parentheses between
+    // last.expression.end and the semicolon, appending one more to
+    // last.expression should be fine.
+    state.prepend(last, 'return (');
+    state.append(last.expression, ')');
+  }
+
+  return wrappedArray.join('');
+}
+
+module.exports = {
+  processTopLevelAwait
+};

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -32,12 +32,22 @@
  *
  */
 
+/* global path */
 /* global util */
 /* global vm */
 
 /* global Context */
 /* global defaultMimer */
 /* global Requester */
+
+var semver = require("semver");
+var processTopLevelAwait;
+if (semver.gte(process.version, "7.6.0")) {
+    processTopLevelAwait = require(
+        path.resolve(__dirname, "lib/server/await.js")).processTopLevelAwait;
+} else {
+    processTopLevelAwait = function() { return null; };
+}
 
 // Shared variables
 var DEBUG = !!process.env.DEBUG;
@@ -314,5 +324,10 @@ function inspect(object) {
 }
 
 function run(code) {
-    return vm.runInThisContext(code);
+    var finalCode = processTopLevelAwait(code);
+    if (!finalCode) {
+        // processTopLevelAwait returns `null` if there is nothing to rewrite
+        finalCode = code;
+    }
+    return vm.runInThisContext(finalCode);
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
         "lint": "eslint index.js lib test",
         "test:jasmine": "jasmine test",
         "test": "npm run lint && npm run test:jasmine"
+    },
+    "dependencies": {
+        "acorn": "^5.7.2",
+        "semver": "^5.5.1"
     }
 }

--- a/test/execute.json
+++ b/test/execute.json
@@ -561,4 +561,51 @@
     "display": [{
         "mime": 1
     }]
+},
+{
+    "node": "7.6.0",
+    "code": "await 5;",
+    "result": {
+        "mime": {
+            "text/plain": "5"
+        }
+    }
+},
+{
+    "node": "7.6.0",
+    "code": "var x = await 10;",
+    "result": {
+        "mime": {
+            "text/plain": "undefined"
+        }
+    }
+},
+{
+    "node": "7.6.0",
+    "code": "var x = await 10;\nconsole.log(x);",
+    "result": {
+        "mime": {
+            "text/plain": "undefined"
+        }
+    },
+    "stdout": "10\n"
+},
+{
+    "node": "7.6.0",
+    "code": "console.log(await 40);",
+    "result": {
+        "mime": {
+            "text/plain": "undefined"
+        }
+    },
+    "stdout": "40\n"
+},
+{
+    "node": "7.6.0",
+    "code": "async function func() { return 7; }\nawait func();",
+    "result": {
+        "mime": {
+            "text/plain": "7"
+        }
+    }
 }]

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,7 @@
 var fs = require("fs");
 var nel = require("../index.js");
 var path = require("path");
+var semver = require("semver");
 
 var depth = 2;
 var inspect = require("util").inspect;
@@ -189,8 +190,10 @@ describe("NEL:", function() {
         var stdout = testCase.stdout;
         var stderr = testCase.stderr;
         var display = testCase.display || [];
+        var nodeVersion = testCase.node || "0.10.0";
 
-        it("can execute '" + code + "'", function(done) {
+        var that = semver.gte(process.version, nodeVersion) ? it : xit;
+        that("can execute '" + code + "'", function(done) {
             log("Test execution case:", code);
 
             var hasRun = [];


### PR DESCRIPTION
The implementation is copied from Node's [`--experimental-repl-await`](https://github.com/nodejs/node/blob/master/lib/internal/repl/await.js)

Screenshot of `ijavascript` with this patch:

![screenshot from 2018-08-27 00-50-34](https://user-images.githubusercontent.com/2793551/44634085-da72a300-a994-11e8-891d-cb429d0d14bc.png)

**DISCLAIMER**: I am a totally lame JS programmer :man_facepalming:: I have to spend some time to figure out how to write tests for this project, how to properly integrate acorn - it is currently integrated the same way as in Node, etc. So consider this a PoC. Feel free to implement everything by yourself and close this PR (I mean, really) or bear with me to make a proper PR. In the latter case I will be grateful for your JS improvement hints and lessons :smile: 
