### PR TITLE
Asynchronous transpiling fix

### DIFF
--- a/lib/nel.js
+++ b/lib/nel.js
@@ -51,12 +51,15 @@ var doc = require("./mdn.js"); // Documentation for Javascript builtins
 var log = require("./log.js")("NEL:");
 var server = require("./server/index.js"); // Server source code
 
+delete global.Promise;
 // acts like 'new Promise(fn)', polyfilling if necessary
 function newPromise(fn) {
     if (global.Promise && typeof global.Promise === "function") {
+        console.log("running with Promise");
         // we have promises, use them
-        return new Promise(fn);
+        return new global.Promise(fn);
     } else {
+        console.log("running with polyfill");
         // create a dumb little synchronous thenable as a promise polyfill
         // NOTE: this assumes that if you don't have built-in promises that your
         // function isn't going to return a Promise or thenable
@@ -845,15 +848,17 @@ Session.prototype._runNow = function(task) {
         // run asynchronous transpiling using a polyfill if necessary
         // for synchronous code this acts like Promise.resolve()
         newPromise(function(resolve, reject) {
+            console.log("transpiling...");
             resolve(this.transpile(task.code));
-        })
+        }.bind(this))
             .then(function(transpiledCode) {
+                console.log("transpiled code", transpiledCode);
                 log("SESSION: RUN: TRANSPILE:\n" + transpiledCode + "\n");
                 task.code = transpiledCode;
                 sendTask();
             })
             .catch(function(err) {
-                sendError(error);
+                sendError(err);
             });
     } else {
         // no transpiling, just run task

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -51,14 +51,40 @@ var doc = require("./mdn.js"); // Documentation for Javascript builtins
 var log = require("./log.js")("NEL:");
 var server = require("./server/index.js"); // Server source code
 
+// acts like 'new Promise(fn)', polyfilling if necessary
+function newPromise(fn) {
+    if (global.Promise && typeof global.Promise === "function") {
+        // we have promises, use them
+        return new Promise(fn);
+    } else {
+        // create a dumb little synchronous thenable as a promise polyfill
+        // NOTE: this assumes that if you don't have built-in promises that your
+        // function isn't going to return a Promise or thenable
+        var fnRet, fnErr;
+        var chainable = {
+            then: function(thenFn) {
+                try {
+                    fn(function resolve(v) {
+                        fnRet = v;
+                    }, function reject(e) {
+                        fnErr = e;
+                    });
+                } catch (err) {
+                    fnErr = err;
+                }
 
-function isPromise(x) {
-    if (!global.Promise || typeof global.Promise !== "function") {
-        return false;
+                if (!fnErr) thenFn(fnRet, fnErr);
+
+                return chainable;
+            },
+            catch: function(catchFn) {
+                if (fnErr) catchFn(fnErr);
+            }
+        };
+
+        return chainable;
     }
-    return x instanceof global.Promise;
 }
-
 
 // File paths
 var paths = {
@@ -816,27 +842,23 @@ Session.prototype._runNow = function(task) {
     }).bind(this);
 
     if (this.transpile && task.action === "run") {
-        try {
-            // Adapted from https://github.com/n-riesco/nel/issues/1 by kebot
-            var transpiledCode = this.transpile(task.code);
-            log("SESSION: RUN: TRANSPILE:\n" + transpiledCode + "\n");
-            if (isPromise(transpiledCode)) {
-                transpiledCode.then(function(value) {
-                    task.code = value;
-                    sendTask();
-                }).catch(sendError);
-                return;
-            } else {
+        // run asynchronous transpiling using a polyfill if necessary
+        // for synchronous code this acts like Promise.resolve()
+        newPromise(function(resolve, reject) {
+            resolve(this.transpile(task.code));
+        })
+            .then(function(transpiledCode) {
+                log("SESSION: RUN: TRANSPILE:\n" + transpiledCode + "\n");
                 task.code = transpiledCode;
-            }
-        } catch (error) {
-            sendError(error);
-            return;
-        }
+                sendTask();
+            })
+            .catch(function(err) {
+                sendError(error);
+            });
+    } else {
+        // no transpiling, just run task
+        sendTask();
     }
-
-    sendTask();
-    return;
 };
 
 /**

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -54,11 +54,9 @@ var server = require("./server/index.js"); // Server source code
 // acts like 'new Promise(fn)', polyfilling if necessary
 function newPromise(fn) {
     if (global.Promise && typeof global.Promise === "function") {
-        console.log("running with Promise");
         // we have promises, use them
         return new global.Promise(fn);
     } else {
-        console.log("running with polyfill");
         // create a dumb little synchronous thenable as a promise polyfill
         // NOTE: this assumes that if you don't have built-in promises that your
         // function isn't going to return a Promise or thenable
@@ -847,11 +845,9 @@ Session.prototype._runNow = function(task) {
         // run asynchronous transpiling using a polyfill if necessary
         // for synchronous code this acts like Promise.resolve()
         newPromise(function(resolve, reject) {
-            console.log("transpiling...");
             resolve(this.transpile(task.code));
         }.bind(this))
             .then(function(transpiledCode) {
-                console.log("transpiled code", transpiledCode);
                 log("SESSION: RUN: TRANSPILE:\n" + transpiledCode + "\n");
                 task.code = transpiledCode;
                 sendTask();

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -51,7 +51,6 @@ var doc = require("./mdn.js"); // Documentation for Javascript builtins
 var log = require("./log.js")("NEL:");
 var server = require("./server/index.js"); // Server source code
 
-delete global.Promise;
 // acts like 'new Promise(fn)', polyfilling if necessary
 function newPromise(fn) {
     if (global.Promise && typeof global.Promise === "function") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nel",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Node.js Evaluation Loop (NEL): module to run a Node.js REPL session",
     "keywords": [
         "javascript",


### PR DESCRIPTION
Related to issue #12

Changes:
* The previous fix would `sendTask` twice with asynchronous code. This adds `sendTask` to an `else` statement in `_runNow` so that runs in either the transpiling OR if the transpiler isn't run.
* Uses a `Promise` if it exists; otherwise does the `try / catch` inside a polyfill. Should make the code easier to upgrade if / when bumping up to a new version of node.js; and makes it easier to read in the meantime.